### PR TITLE
Changed webchat (IRC on freenode) to Discord

### DIFF
--- a/about.html
+++ b/about.html
@@ -29,7 +29,7 @@
             <li><a href="others">Other games</a></li>
             <li><h2>Project links</h2></li>
             <li><a href="https://github.com/performous/performous/wiki" target="_blank">Documentation</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=#performous" target="_blank">Webchat</a></li>
+            <li><a href="https://discord.gg/NS3m3ad" target="_blank">Discord</a></li>
             <li><a href="https://github.com/performous/performous/issues/new" target="_blank">Feedback</a></li>
             <li><a href="https://github.com/performous/performous" target="_blank">Performous@GH</a></li>
             <li><a href="https://github.com/performous/composer" target="_blank">Composer@GH</a></li>

--- a/blog.html
+++ b/blog.html
@@ -29,7 +29,7 @@
             <li><a href="others">Other games</a></li>
             <li><h2>Project links</h2></li>
             <li><a href="https://github.com/performous/performous/wiki" target="_blank">Documentation</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=#performous" target="_blank">Webchat</a></li>
+            <li><a href="https://discord.gg/NS3m3ad" target="_blank">Discord</a></li>
             <li><a href="https://github.com/performous/performous/issues/new" target="_blank">Feedback</a></li>
             <li><a href="https://github.com/performous/performous" target="_blank">Performous@GH</a></li>
             <li><a href="https://github.com/performous/composer" target="_blank">Composer@GH</a></li>

--- a/composer.html
+++ b/composer.html
@@ -29,7 +29,7 @@
             <li><a href="others">Other games</a></li>
             <li><h2>Project links</h2></li>
             <li><a href="https://github.com/performous/performous/wiki" target="_blank">Documentation</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=#performous" target="_blank">Webchat</a></li>
+            <li><a href="https://discord.gg/NS3m3ad" target="_blank">Discord</a></li>
             <li><a href="https://github.com/performous/performous/issues/new" target="_blank">Feedback</a></li>
             <li><a href="https://github.com/performous/performous" target="_blank">Performous@GH</a></li>
             <li><a href="https://github.com/performous/composer" target="_blank">Composer@GH</a></li>

--- a/download.html
+++ b/download.html
@@ -29,7 +29,7 @@
             <li><a href="others">Other games</a></li>
             <li><h2>Project links</h2></li>
             <li><a href="https://github.com/performous/performous/wiki" target="_blank">Documentation</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=#performous" target="_blank">Webchat</a></li>
+            <li><a href="https://discord.gg/NS3m3ad" target="_blank">Discord</a></li>
             <li><a href="https://github.com/performous/performous/issues/new" target="_blank">Feedback</a></li>
             <li><a href="https://github.com/performous/performous" target="_blank">Performous@GH</a></li>
             <li><a href="https://github.com/performous/composer" target="_blank">Composer@GH</a></li>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <li><a href="others">Other games</a></li>
             <li><h2>Project links</h2></li>
             <li><a href="https://github.com/performous/performous/wiki" target="_blank">Documentation</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=#performous" target="_blank">Webchat</a></li>
+            <li><a href="https://discord.gg/NS3m3ad" target="_blank">Discord</a></li>
             <li><a href="https://github.com/performous/performous/issues/new" target="_blank">Feedback</a></li>
             <li><a href="https://github.com/performous/performous" target="_blank">Performous@GH</a></li>
             <li><a href="https://github.com/performous/composer" target="_blank">Composer@GH</a></li>

--- a/others.html
+++ b/others.html
@@ -29,7 +29,7 @@
             <li class="selected"><a href="others">Other games</a></li>
             <li><h2>Project links</h2></li>
             <li><a href="https://github.com/performous/performous/wiki" target="_blank">Documentation</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=#performous" target="_blank">Webchat</a></li>
+            <li><a href="https://discord.gg/NS3m3ad" target="_blank">Discord</a></li>
             <li><a href="https://github.com/performous/performous/issues/new" target="_blank">Feedback</a></li>
             <li><a href="https://github.com/performous/performous" target="_blank">Performous@GH</a></li>
             <li><a href="https://github.com/performous/composer" target="_blank">Composer@GH</a></li>

--- a/songs.html
+++ b/songs.html
@@ -29,7 +29,7 @@
             <li><a href="others">Other games</a></li>
             <li><h2>Project links</h2></li>
             <li><a href="https://github.com/performous/performous/wiki" target="_blank">Documentation</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=#performous" target="_blank">Webchat</a></li>
+            <li><a href="https://discord.gg/NS3m3ad" target="_blank">Discord</a></li>
             <li><a href="https://github.com/performous/performous/issues/new" target="_blank">Feedback</a></li>
             <li><a href="https://github.com/performous/performous" target="_blank">Performous@GH</a></li>
             <li><a href="https://github.com/performous/composer" target="_blank">Composer@GH</a></li>


### PR DESCRIPTION
### What does this PR do?

Removes the webchat (freenode irc) link from the github pages website.
Replaces it with the permanent discord link

### Closes Issue(s)

https://github.com/performous/performous/issues/584

### Motivation

The time of IRC is pretty much gone. Everytime someone asks a question on there and we answer back they are already gone. 
So instead of a web variant of IRC we've grown a pretty big community over at Discord.
For the time being this works good enough. Maybe later integrate with matrix but that has to be researched how to.